### PR TITLE
Close #28, centred frame title (#26), refactor Checkbox/RadioButton

### DIFF
--- a/examples/widget-test/main.cpp
+++ b/examples/widget-test/main.cpp
@@ -104,7 +104,7 @@ public:
             int val = checkbox.enabled() ? -10 : 10;
             bar.value(bar.value() + val);
         };
-        checkbox.onToggle = [&btnIncr](Checkbox& me) {
+        checkbox.onToggle = [&btnIncr](SwearJar::ToggleWidget& me) {
             btnIncr.text(me.enabled() ? L"Decrement" : L"Increment");
         };
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ list (APPEND SwearJarSources
     progressbar.cpp
     collection_widget.cpp
     layout_widget.cpp
+    toggle_widget.cpp
     checkbox.cpp
     list.cpp
     radio_button.cpp
@@ -29,6 +30,7 @@ list(APPEND SwearJarHeaders
     progressbar.h
     collection_widget.h
     layout_widget.h
+    toggle_widget.h
     checkbox.h
     list.h
     radio_button.h

--- a/src/checkbox.cpp
+++ b/src/checkbox.cpp
@@ -2,21 +2,7 @@
 
 namespace SwearJar {
 
-Checkbox::Checkbox(const std::string& name) : Widget(name) {
-    canTakeFocus(true);
-}
-
-void Checkbox::text(const std::wstring& text) {
-    m_text = text;
-    minWidth(text.size() + 4);
-}
-
-void Checkbox::text(const std::string& text) {
-    this->text(convertString(text));
-}
-
-std::wstring Checkbox::text() {
-    return m_text;
+Checkbox::Checkbox(const std::string& name) : ToggleWidget(name) {
 }
 
 void Checkbox::enabled(bool enabled) {
@@ -34,32 +20,9 @@ void Checkbox::toggle() {
 void Checkbox::render(const RenderContext& context) {
     context.drawText(0, 0, L"[ ] ", fgColor(), bgColor());
     context.drawText(4, 0, m_text, fgColor(), bgColor());
-
     if (enabled()) {
         context.drawChar(1, 0, L'X', fgColor(), bgColor());
     }
-}
-
-bool Checkbox::handleKeyPress(const KeyEvent& event) {
-    if (event.key != 10) {
-        return false;
-    }
-
-    toggle();
-
-    if (onToggle != nullptr) {
-        onToggle(*this);
-    }
-    return true;
-}
-
-bool Checkbox::handleMouseClick(const MouseEvent& /* event */) {
-    toggle();
-
-    if (onToggle != nullptr) {
-        onToggle(*this);
-    }
-    return true;
 }
 
 } // namespace SwearJar

--- a/src/checkbox.cpp
+++ b/src/checkbox.cpp
@@ -13,8 +13,9 @@ bool Checkbox::enabled() {
     return m_enabled;
 }
 
-void Checkbox::toggle() {
+bool Checkbox::toggle() {
     enabled(!m_enabled);
+    return true;
 }
 
 void Checkbox::render(const RenderContext& context) {

--- a/src/checkbox.h
+++ b/src/checkbox.h
@@ -12,7 +12,7 @@ public:
 
     void enabled(bool enabled) override;
     bool enabled() override;
-    void toggle() override;
+    bool toggle() override;
 
 private:
     bool m_enabled = false;

--- a/src/checkbox.h
+++ b/src/checkbox.h
@@ -1,30 +1,20 @@
 #pragma once
 
-#include "widget.h"
+#include "toggle_widget.h"
 
 namespace SwearJar {
 
-class Checkbox : public Widget {
+class Checkbox : public ToggleWidget {
 public:
     explicit Checkbox(const std::string& name);
 
     void render(const RenderContext& context) override;
-    bool handleKeyPress(const KeyEvent& event) override;
-    bool handleMouseClick(const MouseEvent& event) override;
 
-    std::function<void(Checkbox&)> onToggle;
-
-    void text(const std::wstring& text);
-    void text(const std::string& text);
-    std::wstring text();
-
-    virtual void enabled(bool enabled);
-    virtual bool enabled();
-
-    virtual void toggle();
+    void enabled(bool enabled) override;
+    bool enabled() override;
+    void toggle() override;
 
 private:
-    std::wstring m_text;
     bool m_enabled = false;
 };
 

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -15,6 +15,14 @@ std::wstring Frame::title() {
     return m_title;
 }
 
+void Frame::titleCentred(bool centred) {
+    m_titleCentred = centred;
+}
+
+bool Frame::titleCentred() {
+    return m_titleCentred;
+}
+
 unsigned int Frame::requiredWidth() {
     unsigned int childWidth = LayoutWidget::requiredWidth() + 2;
     unsigned int frameWidth = title().size() + 4;
@@ -23,7 +31,11 @@ unsigned int Frame::requiredWidth() {
 
 void Frame::render(const RenderContext& context) {
     context.drawBorder(0, 0, width(), height(), fgColor(), bgColor());
-    context.drawText(2, 0, m_title, fgColor(), bgColor());
+    unsigned int xStart = 2;
+    if (m_titleCentred && width() > m_title.size() + 2) {
+        xStart = (width() - m_title.size()) / 2;
+    }
+    context.drawText(xStart, 0, m_title, fgColor(), bgColor());
 
     LayoutWidget::render(context); // render child widgets
 }

--- a/src/frame.h
+++ b/src/frame.h
@@ -10,12 +10,16 @@ public:
     void title(const std::wstring& title);
     std::wstring title();
 
+    void titleCentred(bool centred);
+    bool titleCentred();
+
     unsigned int requiredWidth() override;
 
     void render(const RenderContext& context) override;
 
 private:
     std::wstring m_title;
+    bool m_titleCentred = false;
 };
 
 } // namespace SwearJar

--- a/src/radio_button.cpp
+++ b/src/radio_button.cpp
@@ -31,7 +31,13 @@ RadioButton* RadioButtonGroup::current() {
 }
 
 void RadioButtonGroup::current(RadioButton* button) {
+    if (m_current == button) {
+        return;
+    }
     m_current = button;
+    if (onChanged && button != nullptr) {
+        onChanged(*button);
+    }
 }
 
 RadioButton::RadioButton(const std::string& name) : ToggleWidget(name) {
@@ -59,8 +65,12 @@ void RadioButton::enabled(bool on) {
     m_group->current(this);
 }
 
-void RadioButton::toggle() {
+bool RadioButton::toggle() {
+    if (enabled()) {
+        return false;
+    }
     enabled(true);
+    return true;
 }
 
 void RadioButton::render(const RenderContext& context) {

--- a/src/radio_button.cpp
+++ b/src/radio_button.cpp
@@ -18,10 +18,9 @@ void RadioButtonGroup::add(RadioButton* button) {
 void RadioButtonGroup::remove(RadioButton* button) {
     m_buttons.erase(button);
     if (button == m_current) {
-        if (m_buttons.empty()) {
-            m_current = nullptr;
-        } else {
-            m_current = *m_buttons.begin();
+        m_current = m_buttons.empty() ? nullptr : *m_buttons.begin();
+        if (onChanged && m_current != nullptr) {
+            onChanged(*m_current);
         }
     }
 }

--- a/src/radio_button.cpp
+++ b/src/radio_button.cpp
@@ -34,8 +34,7 @@ void RadioButtonGroup::current(RadioButton* button) {
     m_current = button;
 }
 
-RadioButton::RadioButton(const std::string& name) : Checkbox(name) {
-    //
+RadioButton::RadioButton(const std::string& name) : ToggleWidget(name) {
 }
 
 void RadioButton::group(RadioButtonGroup* group) {
@@ -49,21 +48,27 @@ void RadioButton::group(RadioButtonGroup* group) {
 bool RadioButton::enabled() {
     if (m_group == nullptr) {
         return false;
-        // return Checkbox::enabled(); }
     }
     return m_group->current() == this;
 }
 
-void RadioButton::enabled(bool /* on */) {
-    if (m_group == nullptr) {
-        // Checkbox::enabled(on);
+void RadioButton::enabled(bool on) {
+    if (m_group == nullptr || !on) {
         return;
     }
     m_group->current(this);
 }
 
 void RadioButton::toggle() {
-    this->enabled(true);
+    enabled(true);
+}
+
+void RadioButton::render(const RenderContext& context) {
+    context.drawText(0, 0, L"( ) ", fgColor(), bgColor());
+    context.drawText(4, 0, m_text, fgColor(), bgColor());
+    if (enabled()) {
+        context.drawChar(1, 0, L'*', fgColor(), bgColor());
+    }
 }
 
 RadioButtonGroup* RadioButton::group() {

--- a/src/radio_button.h
+++ b/src/radio_button.h
@@ -1,10 +1,12 @@
 #pragma once
-#include "checkbox.h"
+
+#include "toggle_widget.h"
 #include <set>
 
 namespace SwearJar {
 
 class RadioButton;
+
 class RadioButtonGroup {
 public:
     void add(RadioButton* button);
@@ -21,7 +23,7 @@ private:
     RadioButton* m_current = nullptr;
 };
 
-class RadioButton : public Checkbox {
+class RadioButton : public ToggleWidget {
 public:
     explicit RadioButton(const std::string& name);
 
@@ -29,11 +31,12 @@ public:
     void enabled(bool on) override;
     void toggle() override;
 
+    void render(const RenderContext& context) override;
+
     void group(RadioButtonGroup* group);
     RadioButtonGroup* group();
 
 private:
-    std::string m_title;
     RadioButtonGroup* m_group = nullptr;
 };
 

--- a/src/radio_button.h
+++ b/src/radio_button.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "toggle_widget.h"
+#include <functional>
 #include <set>
 
 namespace SwearJar {
@@ -18,6 +19,8 @@ public:
     void current(RadioButton* button);
     RadioButton* current();
 
+    std::function<void(RadioButton&)> onChanged;
+
 private:
     std::set<RadioButton*> m_buttons;
     RadioButton* m_current = nullptr;
@@ -29,7 +32,7 @@ public:
 
     bool enabled() override;
     void enabled(bool on) override;
-    void toggle() override;
+    bool toggle() override;
 
     void render(const RenderContext& context) override;
 

--- a/src/toggle_widget.cpp
+++ b/src/toggle_widget.cpp
@@ -23,16 +23,14 @@ bool ToggleWidget::handleKeyPress(const KeyEvent& event) {
     if (event.key != 10) {
         return false;
     }
-    toggle();
-    if (onToggle) {
+    if (toggle() && onToggle) {
         onToggle(*this);
     }
     return true;
 }
 
 bool ToggleWidget::handleMouseClick(const MouseEvent& /* event */) {
-    toggle();
-    if (onToggle) {
+    if (toggle() && onToggle) {
         onToggle(*this);
     }
     return true;

--- a/src/toggle_widget.cpp
+++ b/src/toggle_widget.cpp
@@ -1,0 +1,41 @@
+#include "toggle_widget.h"
+
+namespace SwearJar {
+
+ToggleWidget::ToggleWidget(const std::string& name) : Widget(name) {
+    canTakeFocus(true);
+}
+
+void ToggleWidget::text(const std::wstring& text) {
+    m_text = text;
+    minWidth(text.size() + 4);
+}
+
+void ToggleWidget::text(const std::string& text) {
+    this->text(convertString(text));
+}
+
+std::wstring ToggleWidget::text() {
+    return m_text;
+}
+
+bool ToggleWidget::handleKeyPress(const KeyEvent& event) {
+    if (event.key != 10) {
+        return false;
+    }
+    toggle();
+    if (onToggle) {
+        onToggle(*this);
+    }
+    return true;
+}
+
+bool ToggleWidget::handleMouseClick(const MouseEvent& /* event */) {
+    toggle();
+    if (onToggle) {
+        onToggle(*this);
+    }
+    return true;
+}
+
+} // namespace SwearJar

--- a/src/toggle_widget.h
+++ b/src/toggle_widget.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "widget.h"
+#include <functional>
+
+namespace SwearJar {
+
+class ToggleWidget : public Widget {
+public:
+    explicit ToggleWidget(const std::string& name);
+
+    void text(const std::wstring& text);
+    void text(const std::string& text);
+    std::wstring text();
+
+    virtual void enabled(bool enabled) = 0;
+    virtual bool enabled() = 0;
+    virtual void toggle() = 0;
+
+    bool handleKeyPress(const KeyEvent& event) override;
+    bool handleMouseClick(const MouseEvent& event) override;
+
+    std::function<void(ToggleWidget&)> onToggle;
+
+protected:
+    std::wstring m_text;
+};
+
+} // namespace SwearJar

--- a/src/toggle_widget.h
+++ b/src/toggle_widget.h
@@ -15,7 +15,8 @@ public:
 
     virtual void enabled(bool enabled) = 0;
     virtual bool enabled() = 0;
-    virtual void toggle() = 0;
+    // Returns true if state actually changed.
+    virtual bool toggle() = 0;
 
     bool handleKeyPress(const KeyEvent& event) override;
     bool handleMouseClick(const MouseEvent& event) override;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(unit_test
     button.test.cpp
     progressbar.test.cpp
     list.test.cpp
+    toggle_widget.test.cpp
     checkbox.test.cpp
     radio_button.test.cpp
     text_entry.test.cpp

--- a/test/checkbox.test.cpp
+++ b/test/checkbox.test.cpp
@@ -1,4 +1,5 @@
 #include "checkbox.h"
+#include "toggle_widget.h"
 #include "curses.mock.h"
 #include "render_context.mock.h"
 #include <gmock/gmock.h>
@@ -71,7 +72,7 @@ TEST(Checkbox, callsCallbackOnKeyboardToggle) {
     KeyEvent event;
     event.key = 10;
     bool called = false;
-    box.onToggle = [&called](Checkbox&) { called = true; };
+    box.onToggle = [&called](ToggleWidget&) { called = true; };
 
     // When
     box.handleKeyPress(event);
@@ -99,7 +100,7 @@ TEST(Checkbox, callsCallbackOnMouseToggle) {
     Checkbox box("chkTest");
     MouseEvent event;
     bool called = false;
-    box.onToggle = [&called](Checkbox&) { called = true; };
+    box.onToggle = [&called](ToggleWidget&) { called = true; };
 
     // When
     box.handleMouseClick(event);

--- a/test/frame.test.cpp
+++ b/test/frame.test.cpp
@@ -44,6 +44,41 @@ TEST_F(FrameWidget, requiredWidthIsAtLeastTitleWidth) {
     EXPECT_GE(frame.requiredWidth(), frame.title().size());
 }
 
+TEST_F(FrameWidget, titleDefaultsToLeftAligned) {
+    // Given / When
+    EXPECT_FALSE(frame.titleCentred());
+}
+
+TEST_F(FrameWidget, centredTitleRendersMidWidth) {
+    // Given
+    frame.width(20);
+    std::wstring title(L"test");  // length 4 => xStart = (20-4)/2 = 8
+    frame.title(title);
+    frame.titleCentred(true);
+
+    EXPECT_CALL(*context,
+                drawText(8, _, TypedEq<const std::wstring&>(title), _, _));
+    EXPECT_CALL(*context, drawBorder(_, _, _, _, _, _));
+
+    // When
+    frame.render(*context);
+}
+
+TEST_F(FrameWidget, uncentredTitleRendersAtPositionTwo) {
+    // Given
+    frame.width(20);
+    std::wstring title(L"test");
+    frame.title(title);
+    frame.titleCentred(false);
+
+    EXPECT_CALL(*context,
+                drawText(2, _, TypedEq<const std::wstring&>(title), _, _));
+    EXPECT_CALL(*context, drawBorder(_, _, _, _, _, _));
+
+    // When
+    frame.render(*context);
+}
+
 TEST_F(FrameWidget, requiredWidthIsAtLeastChildWidgetWidth) {
     // Given
     auto& w = frame.createWidget<Widget>("testWidget");

--- a/test/radio_button.test.cpp
+++ b/test/radio_button.test.cpp
@@ -1,5 +1,6 @@
 #include "curses.mock.h"
 #include "radio_button.h"
+#include "toggle_widget.h"
 #include "render_context.mock.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -221,6 +222,67 @@ TEST_F(RadioButtonWidget, togglesWhenClicked) {
 
     // Then
     EXPECT_TRUE(button_two.enabled());
+}
+
+TEST_F(RadioButtonWidget, onChangedFiredWhenSelectionChanges) {
+    // Given
+    bool called = false;
+    group.onChanged = [&called](RadioButton&) { called = true; };
+
+    // When
+    button_two.enabled(true);
+
+    // Then
+    EXPECT_TRUE(called);
+}
+
+TEST_F(RadioButtonWidget, onChangedNotFiredWhenSelectionUnchanged) {
+    // Given - button_one is already current
+    bool called = false;
+    group.onChanged = [&called](RadioButton&) { called = true; };
+
+    // When - click the already-selected button
+    button_one.handleMouseClick(mouse);
+
+    // Then
+    EXPECT_FALSE(called);
+}
+
+TEST_F(RadioButtonWidget, onToggleNotFiredWhenAlreadySelected) {
+    // Given - button_one is already current
+    bool called = false;
+    button_one.onToggle = [&called](ToggleWidget&) { called = true; };
+
+    // When
+    key.key = 10;
+    button_one.handleKeyPress(key);
+
+    // Then
+    EXPECT_FALSE(called);
+}
+
+TEST_F(RadioButtonWidget, onChangedFiredWhenCurrentSetDirectlyOnGroup) {
+    // Given
+    bool called = false;
+    group.onChanged = [&called](RadioButton&) { called = true; };
+
+    // When - set selection via group directly
+    group.current(&button_two);
+
+    // Then
+    EXPECT_TRUE(called);
+}
+
+TEST_F(RadioButtonWidget, onChangedNotFiredWhenCurrentSetToSameButton) {
+    // Given - button_one is already current
+    bool called = false;
+    group.onChanged = [&called](RadioButton&) { called = true; };
+
+    // When
+    group.current(&button_one);
+
+    // Then
+    EXPECT_FALSE(called);
 }
 
 TEST_F(RadioButtonWidget, rendersIndicatorWhenEnabled) {

--- a/test/radio_button.test.cpp
+++ b/test/radio_button.test.cpp
@@ -228,7 +228,7 @@ TEST_F(RadioButtonWidget, rendersIndicatorWhenEnabled) {
     auto curses = std::make_shared<NiceMock<MockCurses>>();
     auto context = std::make_unique<NiceMock<MockRenderContext>>(*curses);
 
-    EXPECT_CALL(*context, drawChar(_, _, TypedEq<wchar_t>('X'), _, _)).Times(1);
+    EXPECT_CALL(*context, drawChar(_, _, TypedEq<wchar_t>('*'), _, _)).Times(1);
 
     // When
     button_one.render(*context);
@@ -239,7 +239,7 @@ TEST_F(RadioButtonWidget, doesntRenderIndicatorWhenNotEnabled) {
     auto curses = std::make_shared<NiceMock<MockCurses>>();
     auto context = std::make_unique<NiceMock<MockRenderContext>>(*curses);
 
-    EXPECT_CALL(*context, drawChar(_, _, TypedEq<wchar_t>('X'), _, _)).Times(0);
+    EXPECT_CALL(*context, drawChar(_, _, TypedEq<wchar_t>('*'), _, _)).Times(0);
 
     // When
     button_two.render(*context);

--- a/test/radio_button.test.cpp
+++ b/test/radio_button.test.cpp
@@ -285,6 +285,31 @@ TEST_F(RadioButtonWidget, onChangedNotFiredWhenCurrentSetToSameButton) {
     EXPECT_FALSE(called);
 }
 
+TEST_F(RadioButtonWidget, onChangedFiredWhenCurrentButtonRemoved) {
+    // Given - button_one is current; removing it promotes button_two
+    bool called = false;
+    group.onChanged = [&called](RadioButton&) { called = true; };
+
+    // When
+    group.remove(&button_one);
+
+    // Then
+    EXPECT_TRUE(called);
+    EXPECT_EQ(group.current(), &button_two);
+}
+
+TEST_F(RadioButtonWidget, onChangedNotFiredWhenNonCurrentButtonRemoved) {
+    // Given
+    bool called = false;
+    group.onChanged = [&called](RadioButton&) { called = true; };
+
+    // When - remove the non-current button
+    group.remove(&button_two);
+
+    // Then
+    EXPECT_FALSE(called);
+}
+
 TEST_F(RadioButtonWidget, rendersIndicatorWhenEnabled) {
     // Given
     auto curses = std::make_shared<NiceMock<MockCurses>>();

--- a/test/toggle_widget.test.cpp
+++ b/test/toggle_widget.test.cpp
@@ -1,0 +1,78 @@
+#include "checkbox.h"
+#include "curses.mock.h"
+#include "render_context.mock.h"
+#include "toggle_widget.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using namespace SwearJar;
+
+// Use Checkbox as a concrete ToggleWidget for testing the shared base behaviour.
+class ToggleWidgetBase : public Test {
+protected:
+    Checkbox widget{"twTest"};
+    KeyEvent kevent;
+    MouseEvent mevent;
+};
+
+TEST_F(ToggleWidgetBase, canTakeFocus) {
+    EXPECT_TRUE(widget.canTakeFocus());
+}
+
+TEST_F(ToggleWidgetBase, canSetWideText) {
+    widget.text(L"Hello");
+    EXPECT_EQ(L"Hello", widget.text());
+}
+
+TEST_F(ToggleWidgetBase, canSetNarrowText) {
+    widget.text(std::string("Hello"));
+    EXPECT_EQ(L"Hello", widget.text());
+}
+
+TEST_F(ToggleWidgetBase, settingTextSetsMinWidth) {
+    widget.text(L"Hi");
+    EXPECT_EQ(6u, widget.requiredWidth()); // text.size() + 4
+}
+
+TEST_F(ToggleWidgetBase, enterKeyCallsToggle) {
+    kevent.key = 10;
+    bool toggled = widget.enabled();
+    widget.handleKeyPress(kevent);
+    EXPECT_NE(toggled, widget.enabled());
+}
+
+TEST_F(ToggleWidgetBase, otherKeyDoesNothing) {
+    kevent.key = 'x';
+    bool toggled = widget.enabled();
+    bool handled = widget.handleKeyPress(kevent);
+    EXPECT_FALSE(handled);
+    EXPECT_EQ(toggled, widget.enabled());
+}
+
+TEST_F(ToggleWidgetBase, mouseClickCallsToggle) {
+    bool toggled = widget.enabled();
+    widget.handleMouseClick(mevent);
+    EXPECT_NE(toggled, widget.enabled());
+}
+
+TEST_F(ToggleWidgetBase, enterKeyFiresOnToggleCallback) {
+    kevent.key = 10;
+    bool called = false;
+    widget.onToggle = [&called](ToggleWidget&) { called = true; };
+    widget.handleKeyPress(kevent);
+    EXPECT_TRUE(called);
+}
+
+TEST_F(ToggleWidgetBase, mouseClickFiresOnToggleCallback) {
+    bool called = false;
+    widget.onToggle = [&called](ToggleWidget&) { called = true; };
+    widget.handleMouseClick(mevent);
+    EXPECT_TRUE(called);
+}
+
+TEST_F(ToggleWidgetBase, onToggleNotCalledIfNotSet) {
+    kevent.key = 10;
+    widget.onToggle = nullptr;
+    EXPECT_NO_THROW(widget.handleKeyPress(kevent));
+}


### PR DESCRIPTION
## Summary

- **Closes #28** — `Screen` copy constructor was already deleted; issue closed.
- **Closes #26** — `Frame::titleCentred(bool)` added; when true the title is centred within the frame border instead of fixed at column 2.
- **`ToggleWidget` base class** — extracted from `Checkbox` to hold text management (`text()`, `m_text`, `minWidth`) and input dispatch (`handleKeyPress`, `handleMouseClick`, `onToggle`). `toggle()` returns `bool` so callbacks are only fired when state actually changes.
- **`Checkbox`** inherits from `ToggleWidget`; unchanged behaviour, less code.
- **`RadioButton`** now inherits from `ToggleWidget` directly (no longer from `Checkbox`). Gets its own `render()` with `( )` / `(*)` brackets. Dead `m_title` field and commented-out code removed.
- **`RadioButtonGroup::onChanged`** — single callback on the group, fired on any selection change (button interaction, `group.current()`, or removal of the current button). All three paths guard against spurious no-op notifications.

## Test plan
- [ ] All 248 existing + new tests pass
- [ ] `Frame` centred/uncentred title renders at the correct x position
- [ ] `ToggleWidget` base behaviour (text, focus, input, callback) covered by `toggle_widget.test.cpp`
- [ ] `RadioButtonGroup::onChanged` fires on selection change and not on no-change
- [ ] Clicking the already-selected radio button does not fire any callback
- [ ] Removing the current button fires `onChanged` with the newly promoted button
- [ ] Removing a non-current button does not fire `onChanged`

https://claude.ai/code/session_01T6cnE3mMQXrXotQLXatRPd